### PR TITLE
Improve code quality (based on clippy command output)

### DIFF
--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -170,6 +170,15 @@ impl From<KakarotClientError> for jsonrpsee::core::Error {
 }
 
 impl KakarotClientImpl {
+    /// Create a new `KakarotClient`.
+    ///
+    /// # Arguments
+    ///
+    /// * `starknet_rpc(&str)` - `StarkNet` RPC
+    ///
+    /// # Errors
+    ///
+    /// `Err(KakarotClientError)` if the operation failed.
     pub fn new(starknet_rpc: &str) -> Result<Self> {
         let url = Url::parse(starknet_rpc)?;
         let kakarot_main_contract = FieldElement::from_hex_be(KAKAROT_MAIN_CONTRACT_ADDRESS)?;
@@ -632,10 +641,10 @@ impl KakarotClient for KakarotClientImpl {
                     res_receipt.transaction_hash =
                         Some(H256::from(&transaction_hash.to_bytes_be()));
                     res_receipt.status_code = match status {
-                        StarknetTransactionStatus::Pending => Some(U64::from(0)),
-                        StarknetTransactionStatus::AcceptedOnL1 => Some(U64::from(1)),
-                        StarknetTransactionStatus::AcceptedOnL2 => Some(U64::from(1)),
-                        StarknetTransactionStatus::Rejected => Some(U64::from(0)),
+                        StarknetTransactionStatus::Rejected
+                        | StarknetTransactionStatus::Pending => Some(U64::from(0)),
+                        StarknetTransactionStatus::AcceptedOnL1
+                        | StarknetTransactionStatus::AcceptedOnL2 => Some(U64::from(1)),
                     };
                     res_receipt.block_hash = Some(H256::from(&block_hash.to_bytes_be()));
                     res_receipt.block_number = Some(U256::from(block_number));
@@ -1305,7 +1314,7 @@ impl KakarotClient for KakarotClientImpl {
                 .starknet_tx_into_kakarot_tx(transaction, blockhash_opt, blocknum_opt)
                 .await;
             if let Ok(val) = tx_value {
-                transactions_vec.push(val)
+                transactions_vec.push(val);
             }
         }
         Ok(BlockTransactions::Full(transactions_vec))

--- a/core/src/utils/wiremock_utils.rs
+++ b/core/src/utils/wiremock_utils.rs
@@ -1,9 +1,9 @@
-use std::str::FromStr;
-
 use crate::helpers::ethers_block_id_to_starknet_block_id;
+use reqwest::StatusCode;
 use reth_primitives::{BlockId, H256};
 use serde::{Deserialize, Serialize};
 use starknet::providers::jsonrpc::models::{BlockId as StarknetBlockId, BlockTag};
+use std::str::FromStr;
 use wiremock::{
     matchers::{body_json, method},
     Mock, MockServer, ResponseTemplate,
@@ -35,7 +35,7 @@ pub struct EthGetChainId {
 }
 
 impl<'a, StarknetParams> StarknetRpcBaseData<'a, StarknetParams> {
-    pub fn block_number(params: StarknetParams) -> Self {
+    pub const fn block_number(params: StarknetParams) -> Self {
         Self {
             id: 1,
             jsonrpc: "2.0",
@@ -44,7 +44,7 @@ impl<'a, StarknetParams> StarknetRpcBaseData<'a, StarknetParams> {
         }
     }
 
-    pub fn block_with_txs(params: StarknetParams) -> Self {
+    pub const fn block_with_txs(params: StarknetParams) -> Self {
         Self {
             id: 1,
             jsonrpc: "2.0",
@@ -53,7 +53,7 @@ impl<'a, StarknetParams> StarknetRpcBaseData<'a, StarknetParams> {
         }
     }
 
-    pub fn block_with_tx_hashes(params: StarknetParams) -> Self {
+    pub const fn block_with_tx_hashes(params: StarknetParams) -> Self {
         Self {
             id: 1,
             jsonrpc: "2.0",
@@ -62,7 +62,7 @@ impl<'a, StarknetParams> StarknetRpcBaseData<'a, StarknetParams> {
         }
     }
 
-    pub fn transaction_by_block_id_and_index(params: StarknetParams) -> Self {
+    pub const fn transaction_by_block_id_and_index(params: StarknetParams) -> Self {
         Self {
             id: 1,
             jsonrpc: "2.0",
@@ -71,7 +71,7 @@ impl<'a, StarknetParams> StarknetRpcBaseData<'a, StarknetParams> {
         }
     }
 
-    pub fn transaction_receipt(params: StarknetParams) -> Self {
+    pub const fn transaction_receipt(params: StarknetParams) -> Self {
         Self {
             id: 1,
             jsonrpc: "2.0",
@@ -80,7 +80,7 @@ impl<'a, StarknetParams> StarknetRpcBaseData<'a, StarknetParams> {
         }
     }
 
-    pub fn transaction_by_hash(params: StarknetParams) -> Self {
+    pub const fn transaction_by_hash(params: StarknetParams) -> Self {
         Self {
             id: 1,
             jsonrpc: "2.0",
@@ -89,7 +89,7 @@ impl<'a, StarknetParams> StarknetRpcBaseData<'a, StarknetParams> {
         }
     }
 
-    pub fn call(params: StarknetParams) -> Self {
+    pub const fn call(params: StarknetParams) -> Self {
         Self {
             id: 1,
             jsonrpc: "2.0",
@@ -98,7 +98,7 @@ impl<'a, StarknetParams> StarknetRpcBaseData<'a, StarknetParams> {
         }
     }
 
-    pub fn class_hash_at(params: StarknetParams) -> Self {
+    pub const fn class_hash_at(params: StarknetParams) -> Self {
         Self {
             id: 1,
             jsonrpc: "2.0",
@@ -111,22 +111,68 @@ impl<'a, StarknetParams> StarknetRpcBaseData<'a, StarknetParams> {
 pub async fn setup_wiremock() -> String {
     let mock_server = MockServer::start().await;
 
-    // block_number
-    Mock::given(method("POST"))
-        .and(body_json(StarknetRpcBaseData::block_number(())))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_raw(
-                    include_str!("data/blocks/starknet_blockNumber.json"),
-                    "application/json",
-                )
-                .append_header("vary", "Accept-Encoding")
-                .append_header("vary", "Origin"),
-        )
+    mock_block_number().mount(&mock_server).await;
+
+    mock_block_with_txs().mount(&mock_server).await;
+
+    mock_block_with_txs_hashes().mount(&mock_server).await;
+
+    mock_block_with_txs_latest().mount(&mock_server).await;
+
+    mock_block_with_txs_hashes_latest()
         .mount(&mock_server)
         .await;
 
-    // block_with_txs
+    // block_with_txs & block_with_tx_hashes from pending
+    mock_block_with_txs_pending().mount(&mock_server).await;
+
+    mock_block_with_txs_hash_pending().mount(&mock_server).await;
+
+    // transaction_by_block_hash_and_index from latest
+    mock_transaction_by_block_hash_and_index_latest()
+        .mount(&mock_server)
+        .await;
+
+    // * test_transaction_by_block_hash_and_index_is_ok
+    // transaction_by_block_hash_and_index from block hash
+    mock_transaction_by_block_hash_and_index()
+        .mount(&mock_server)
+        .await;
+
+    // transaction_receipt for transaction_by_block_hash_and_index from block hash
+    mock_transaction_receipt_for_transaction_by_block_hash_and_index()
+        .mount(&mock_server)
+        .await;
+
+    // * test_transaction_receipt_invoke_is_ok
+    mock_transaction_receipt_invoke_is_ok()
+        .mount(&mock_server)
+        .await;
+
+    mock_transaction_by_hash().mount(&mock_server).await;
+
+    mock_get_code().mount(&mock_server).await;
+
+    mock_get_evm_address().mount(&mock_server).await;
+
+    mock_get_class_hash_at().mount(&mock_server).await;
+
+    // Get kakarot contract bytecode
+    // TODO: Use the latest mapping between starknet and EVM adresses
+
+    mock_server.uri()
+}
+
+fn mock_block_number() -> Mock {
+    Mock::given(method("POST"))
+        .and(body_json(StarknetRpcBaseData::block_number(())))
+        .respond_with(response_template_with_status(StatusCode::OK).set_body_raw(
+            include_str!("data/blocks/starknet_blockNumber.json"),
+            "application/json",
+        ))
+}
+
+fn mock_block_with_txs() -> Mock {
     let block_id = BlockId::Hash(
         H256::from_str("0x0449aa33ad836b65b10fa60082de99e24ac876ee2fd93e723a99190a530af0a9")
             .unwrap()
@@ -137,19 +183,13 @@ pub async fn setup_wiremock() -> String {
         .and(body_json(StarknetRpcBaseData::block_with_txs([
             &starknet_block_id,
         ])))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_raw(
-                    include_str!("data/blocks/starknet_getBlockWithTxs.json"),
-                    "application/json",
-                )
-                .append_header("vary", "Accept-Encoding")
-                .append_header("vary", "Origin"),
-        )
-        .mount(&mock_server)
-        .await;
+        .respond_with(response_template_with_status(StatusCode::OK).set_body_raw(
+            include_str!("data/blocks/starknet_getBlockWithTxs.json"),
+            "application/json",
+        ))
+}
 
-    // block_with_tx_hashes
+fn mock_block_with_txs_hashes() -> Mock {
     let block_id_tx_hashes = BlockId::Hash(
         H256::from_str("0x0197be2810df6b5eedd5d9e468b200d0b845b642b81a44755e19047f08cc8c6e")
             .unwrap()
@@ -161,87 +201,62 @@ pub async fn setup_wiremock() -> String {
         .and(body_json(StarknetRpcBaseData::block_with_tx_hashes([
             &starknet_block_id_tx_hashes,
         ])))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_raw(
-                    include_str!("data/blocks/starknet_getBlockWithTxHashes.json"),
-                    "application/json",
-                )
-                .append_header("vary", "Accept-Encoding")
-                .append_header("vary", "Origin"),
-        )
-        .mount(&mock_server)
-        .await;
+        .respond_with(response_template_with_status(StatusCode::OK).set_body_raw(
+            include_str!("data/blocks/starknet_getBlockWithTxHashes.json"),
+            "application/json",
+        ))
+}
 
-    // block_with_txs latest
+fn mock_block_with_txs_latest() -> Mock {
     let latest_block = StarknetBlockId::Tag(BlockTag::Latest);
     Mock::given(method("POST"))
         .and(body_json(StarknetRpcBaseData::block_with_txs([
             &latest_block,
         ])))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_raw(
-                    include_str!("data/blocks/starknet_getBlockWithTxs.json"),
-                    "application/json",
-                )
-                .append_header("vary", "Accept-Encoding")
-                .append_header("vary", "Origin"),
-        )
-        .mount(&mock_server)
-        .await;
+        .respond_with(response_template_with_status(StatusCode::OK).set_body_raw(
+            include_str!("data/blocks/starknet_getBlockWithTxs.json"),
+            "application/json",
+        ))
+}
 
-    // block_with_tx_hashes latest
+fn mock_block_with_txs_hashes_latest() -> Mock {
+    let latest_block = StarknetBlockId::Tag(BlockTag::Latest);
     Mock::given(method("POST"))
         .and(body_json(StarknetRpcBaseData::block_with_tx_hashes([
             &latest_block,
         ])))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_raw(
-                    include_str!("data/blocks/starknet_getBlockWithTxHashes.json"),
-                    "application/json",
-                )
-                .append_header("vary", "Accept-Encoding")
-                .append_header("vary", "Origin"),
-        )
-        .mount(&mock_server)
-        .await;
+        .respond_with(response_template_with_status(StatusCode::OK).set_body_raw(
+            include_str!("data/blocks/starknet_getBlockWithTxHashes.json"),
+            "application/json",
+        ))
+}
 
-    // block_with_txs & block_with_tx_hashes from pending
+fn mock_block_with_txs_pending() -> Mock {
     let pending_block = StarknetBlockId::Tag(BlockTag::Pending);
     Mock::given(method("POST"))
         .and(body_json(StarknetRpcBaseData::block_with_txs([
             &pending_block,
         ])))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_raw(
-                    include_str!("data/blocks/starknet_getBlockWithTxs.json"),
-                    "application/json",
-                )
-                .append_header("vary", "Accept-Encoding")
-                .append_header("vary", "Origin"),
-        )
-        .mount(&mock_server)
-        .await;
+        .respond_with(response_template_with_status(StatusCode::OK).set_body_raw(
+            include_str!("data/blocks/starknet_getBlockWithTxs.json"),
+            "application/json",
+        ))
+}
+
+fn mock_block_with_txs_hash_pending() -> Mock {
+    let pending_block = StarknetBlockId::Tag(BlockTag::Pending);
     Mock::given(method("POST"))
         .and(body_json(StarknetRpcBaseData::block_with_tx_hashes([
             &pending_block,
         ])))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_raw(
-                    include_str!("data/blocks/starknet_getBlockWithTxHashes.json"),
-                    "application/json",
-                )
-                .append_header("vary", "Accept-Encoding")
-                .append_header("vary", "Origin"),
-        )
-        .mount(&mock_server)
-        .await;
+        .respond_with(response_template_with_status(StatusCode::OK).set_body_raw(
+            include_str!("data/blocks/starknet_getBlockWithTxHashes.json"),
+            "application/json",
+        ))
+}
 
-    // transaction_by_block_hash_and_index from latest
+fn mock_transaction_by_block_hash_and_index_latest() -> Mock {
+    let latest_block = StarknetBlockId::Tag(BlockTag::Latest);
     Mock::given(method("POST"))
         .and(body_json(
             StarknetRpcBaseData::transaction_by_block_id_and_index([
@@ -249,20 +264,13 @@ pub async fn setup_wiremock() -> String {
                 serde_json::to_value(0).unwrap(),
             ]),
         ))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_raw(
-                    include_str!("data/transactions/starknet_getTransactionByBlockIdAndIndex.json"),
-                    "application/json",
-                )
-                .append_header("vary", "Accept-Encoding")
-                .append_header("vary", "Origin"),
-        )
-        .mount(&mock_server)
-        .await;
+        .respond_with(response_template_with_status(StatusCode::OK).set_body_raw(
+            include_str!("data/transactions/starknet_getTransactionByBlockIdAndIndex.json"),
+            "application/json",
+        ))
+}
 
-    // * test_transaction_by_block_hash_and_index_is_ok
-    // transaction_by_block_hash_and_index from block hash
+fn mock_transaction_by_block_hash_and_index() -> Mock {
     Mock::given(method("POST"))
         .and(body_json(
             StarknetRpcBaseData::transaction_by_block_id_and_index([
@@ -270,67 +278,47 @@ pub async fn setup_wiremock() -> String {
                 serde_json::to_value(0).unwrap(),
             ]),
         ))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_raw(
-                    include_str!("data/transactions/starknet_getTransactionByBlockIdAndIndex.json"),
-                    "application/json",
-                )
-                .append_header("vary", "Accept-Encoding")
-                .append_header("vary", "Origin"),
-        )
-        .mount(&mock_server)
-        .await;
+        .respond_with(response_template_with_status(StatusCode::OK).set_body_raw(
+            include_str!("data/transactions/starknet_getTransactionByBlockIdAndIndex.json"),
+            "application/json",
+        ))
+}
 
-    // transaction_receipt for transaction_by_block_hash_and_index from block hash
+fn mock_transaction_receipt_for_transaction_by_block_hash_and_index() -> Mock {
     Mock::given(method("POST"))
         .and(body_json(StarknetRpcBaseData::transaction_receipt([
             "0x7c5df940744056d337c3de6e8f4500db4b9bfc821eb534b891555e90c39c048",
         ])))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_raw(
-                    include_str!("data/transactions/starknet_getTransactionReceipt.json"),
-                    "application/json",
-                )
-                .append_header("vary", "Accept-Encoding")
-                .append_header("vary", "Origin"),
-        )
-        .mount(&mock_server)
-        .await;
+        .respond_with(response_template_with_status(StatusCode::OK).set_body_raw(
+            include_str!("data/transactions/starknet_getTransactionReceipt.json"),
+            "application/json",
+        ))
+}
 
-    // * test_transaction_receipt_invoke_is_ok
+fn mock_transaction_receipt_invoke_is_ok() -> Mock {
     Mock::given(method("POST"))
         .and(body_json(StarknetRpcBaseData::transaction_receipt([
             "0x32e08cabc0f34678351953576e64f300add9034945c4bffd355de094fd97258",
         ])))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_raw(
-                    include_str!("data/transactions/starknet_getTransactionReceipt_Invoke.json"),
-                    "application/json",
-                )
-                .append_header("vary", "Accept-Encoding")
-                .append_header("vary", "Origin"),
-        )
-        .mount(&mock_server)
-        .await;
+        .respond_with(response_template_with_status(StatusCode::OK).set_body_raw(
+            include_str!("data/transactions/starknet_getTransactionReceipt_Invoke.json"),
+            "application/json",
+        ))
+}
+
+fn mock_transaction_by_hash() -> Mock {
     Mock::given(method("POST"))
         .and(body_json(StarknetRpcBaseData::transaction_by_hash([
             "0x32e08cabc0f34678351953576e64f300add9034945c4bffd355de094fd97258",
         ])))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_raw(
-                    include_str!("data/transactions/starknet_getTransactionByHash_Invoke.json"),
-                    "application/json",
-                )
-                .append_header("vary", "Accept-Encoding")
-                .append_header("vary", "Origin"),
-        )
-        .mount(&mock_server)
-        .await;
+        .respond_with(response_template_with_status(StatusCode::OK).set_body_raw(
+            include_str!("data/transactions/starknet_getTransactionByHash_Invoke.json"),
+            "application/json",
+        ))
+}
 
+fn mock_get_code() -> Mock {
+    let latest_block = StarknetBlockId::Tag(BlockTag::Latest);
     let get_code_call_request = serde_json::json!({
         "contract_address": "0xd90fd6aa27edd344c5cbe1fe999611416b268658e866a54265aaf50d9cf28d",
         "entry_point_selector": "0x2f22d9e1ae4a391b4a190b8225f2f6f772a083382b7ded3e8d85743a8fcfdcd",
@@ -341,18 +329,14 @@ pub async fn setup_wiremock() -> String {
             serde_json::to_value(get_code_call_request).unwrap(),
             serde_json::to_value(&latest_block).unwrap(),
         ])))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_raw(
-                    include_str!("data/starknet_getCode.json"),
-                    "application/json",
-                )
-                .append_header("vary", "Accept-Encoding")
-                .append_header("vary", "Origin"),
-        )
-        .mount(&mock_server)
-        .await;
+        .respond_with(response_template_with_status(StatusCode::OK).set_body_raw(
+            include_str!("data/starknet_getCode.json"),
+            "application/json",
+        ))
+}
 
+fn mock_get_evm_address() -> Mock {
+    let latest_block = StarknetBlockId::Tag(BlockTag::Latest);
     let get_evm_address_call_request = serde_json::json!({
         "contract_address": "0xd90fd6aa27edd344c5cbe1fe999611416b268658e866a54265aaf50d9cf28d",
         "entry_point_selector": "0x158359fe4236681f6236a2f303f9350495f73f078c9afd1ca0890fa4143c2ed",
@@ -363,18 +347,14 @@ pub async fn setup_wiremock() -> String {
             serde_json::to_value(get_evm_address_call_request).unwrap(),
             serde_json::to_value(&latest_block).unwrap(),
         ])))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_raw(
-                    include_str!("data/kakarot_getEvmAddress.json"),
-                    "application/json",
-                )
-                .append_header("vary", "Accept-Encoding")
-                .append_header("vary", "Origin"),
-        )
-        .mount(&mock_server)
-        .await;
+        .respond_with(response_template_with_status(StatusCode::OK).set_body_raw(
+            include_str!("data/kakarot_getEvmAddress.json"),
+            "application/json",
+        ))
+}
 
+fn mock_get_class_hash_at() -> Mock {
+    let latest_block = StarknetBlockId::Tag(BlockTag::Latest);
     Mock::given(method("POST"))
         .and(body_json(StarknetRpcBaseData::class_hash_at([
             serde_json::to_value(&latest_block).unwrap(),
@@ -383,20 +363,14 @@ pub async fn setup_wiremock() -> String {
             )
             .unwrap(),
         ])))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_raw(
-                    include_str!("data/transactions/starknet_getClassHashAt.json"),
-                    "application/json",
-                )
-                .append_header("vary", "Accept-Encoding")
-                .append_header("vary", "Origin"),
-        )
-        .mount(&mock_server)
-        .await;
+        .respond_with(response_template_with_status(StatusCode::OK).set_body_raw(
+            include_str!("data/transactions/starknet_getClassHashAt.json"),
+            "application/json",
+        ))
+}
 
-    // Get kakarot contract bytecode
-    // TODO: Use the latest mapping between starknet and EVM adresses
-
-    mock_server.uri()
+fn response_template_with_status(status_code: StatusCode) -> ResponseTemplate {
+    ResponseTemplate::new(status_code)
+        .append_header("vary", "Accept-Encoding")
+        .append_header("vary", "Origin")
 }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -16,11 +16,14 @@ pub enum RpcError {
     ParseError(#[from] AddrParseError),
 }
 
+/// # Errors
+///
+/// Will return `Err` if an error occurs when running the `ServerBuilder` start fails.
 pub async fn run_server(
     starknet_client: Box<dyn KakarotClient>,
 ) -> Result<(SocketAddr, ServerHandle), RpcError> {
     let socket_addr =
-        std::env::var("KAKAROT_HTTP_RPC_ADDRESS").unwrap_or("0.0.0.0:3030".to_owned());
+        std::env::var("KAKAROT_HTTP_RPC_ADDRESS").unwrap_or_else(|_| "0.0.0.0:3030".to_owned());
 
     let server = ServerBuilder::default()
         .build(socket_addr.parse::<SocketAddr>()?)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days. Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: 0.5 days

<!-- Which issue is this PR related to? -->

Closes #NUMBER_OF_ISSUE

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?
Issue Number: [#112](https://github.com/sayajin-labs/kakarot-rpc/issues/112)

Resolve code quality issues for command:
`cargo clippy --  -W clippy::pedantic -W clippy::nursery -W clippy::expect_used`

# What is the new behavior?
This PR has no changes in behavior.

# Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information
There are still some issues that I could not solve because they implied large (or complex) changes and I would like to see them monitored, these are the following:
1. 
![image](https://user-images.githubusercontent.com/58611754/221687761-ad80a4fd-7039-4288-8037-ebf1581ffa00.png)

2. 
![image](https://user-images.githubusercontent.com/58611754/221688098-a470e5df-0d60-4d0c-8a18-aad115b901e1.png)

3.
![image](https://user-images.githubusercontent.com/58611754/221688188-2025366d-36ac-4fe1-aa08-4a66443d1ba4.png)

4.
![image](https://user-images.githubusercontent.com/58611754/221688237-ab6495da-05d3-4cc6-b989-cd800017338b.png)

5.
![image](https://user-images.githubusercontent.com/58611754/221688324-01e386f7-adb6-49f3-add1-d71da8e75b59.png)

6.
![image](https://user-images.githubusercontent.com/58611754/221688430-2f829587-4213-4b8b-89a7-38ce17d9f32c.png)

